### PR TITLE
Temporary sas files as arguments and fix OSI install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Instal open solver interface.
 export DOWNWARD_COIN_ROOT=/path/to/osi
 sudo apt install zlib1g-dev
 wget http://www.coin-or.org/download/source/Osi/Osi-0.107.9.tgz
+tar -xzf Osi-0.107.9.tgz
 cd Osi-0.107.9
 ./configure CC="gcc"  CFLAGS="-pthread -Wno-long-long" \
             CXX="g++" CXXFLAGS="-pthread -Wno-long-long" \

--- a/driver/arguments.py
+++ b/driver/arguments.py
@@ -3,10 +3,7 @@
 import argparse
 import os.path
 
-from . import aliases
-from . import limits
-from . import util
-
+from . import aliases, limits, util
 
 DESCRIPTION = """Fast Downward driver script.
 
@@ -232,8 +229,13 @@ def _set_components_and_inputs(parser, args):
         args.components.append("validate")
 
     args.translate_inputs = []
-    args.preprocess_input = "output.sas"
-    args.search_input = "output"
+    args.preprocess_input = args.sas_file
+
+    # see src/preprocess/planner.cc main
+    args.preprocess_options = [args.sas_file]
+
+    # see src/preprocess/helper_functions.cc generate_cpp_input
+    args.search_input = args.sas_file + ".num"
 
     assert args.components
     first = args.components[0]
@@ -253,6 +255,7 @@ def _set_components_and_inputs(parser, args):
             args.translate_inputs = args.filenames
         else:
             parser.error("translator needs one or two input files")
+        args.translate_inputs += ["--sas_file", args.sas_file]
     elif first == "preprocess":
         if "--help" in args.preprocess_options:
             args.preprocess_input = None
@@ -267,6 +270,7 @@ def _set_components_and_inputs(parser, args):
             args.search_input, = args.filenames
         else:
             parser.error("search needs exactly one input file")
+        # args.search_input += ["--num_sas_file", nsas_file]
     else:
         assert False, first
 
@@ -365,6 +369,8 @@ def parse_args():
     # because the argument is a filename; in exceptional cases, "--"
     # can be used as an explicit separator. For example, "./fast-downward.py --
     # --help" passes "--help" to the search code.
+
+    parser.add_argument("--sas_file", help="path to output sas file")
 
     args = parser.parse_args()
 

--- a/driver/cleanup.py
+++ b/driver/cleanup.py
@@ -1,5 +1,6 @@
-from itertools import count
 import os
+from itertools import count
+
 
 def _try_remove(f):
     try:
@@ -9,8 +10,8 @@ def _try_remove(f):
     return True
 
 def cleanup_temporary_files(args):
-    _try_remove("output.sas")
-    _try_remove("output")
+    _try_remove(args.sas_file)
+    _try_remove(args.sas_file + ".num")
     _try_remove(args.plan_file)
 
     for i in count(1):

--- a/src/preprocess/helper_functions.cc
+++ b/src/preprocess/helper_functions.cc
@@ -303,7 +303,8 @@ void dump_DTGs(const vector<Variable *> &ordering,
     }
 }
 
-void generate_cpp_input(bool /*solvable_in_poly_time*/,
+void generate_cpp_input(const string in_file,
+                        bool /*solvable_in_poly_time*/,
                         const vector<Variable *> &ordered_vars,
                         const vector<NumericVariable *> &numeric_vars,
                         const Metric &metric,
@@ -322,7 +323,7 @@ void generate_cpp_input(bool /*solvable_in_poly_time*/,
        since the planner doesn't handle it specially any more anyway. */
 
     ofstream outfile;
-    outfile.open("output", ios::out);
+    outfile.open(in_file + ".num", ios::out);
 
     outfile << "begin_version" << endl;
     outfile << PRE_FILE_VERSION << endl;

--- a/src/preprocess/helper_functions.h
+++ b/src/preprocess/helper_functions.h
@@ -59,7 +59,8 @@ void dump_preprocessed_problem_description(const vector<Variable *> &variables,
 
 void dump_DTGs(const vector<Variable *> &ordering,
                vector<DomainTransitionGraph> &transition_graphs);
-void generate_cpp_input(bool causal_graph_acyclic,
+void generate_cpp_input(const string in_file,
+                        bool causal_graph_acyclic,
                         const vector<Variable *> &ordered_var,
                         const vector<NumericVariable *> &numeric_var,
                         const Metric &metric,

--- a/src/preprocess/planner.cc
+++ b/src/preprocess/planner.cc
@@ -44,10 +44,12 @@ int main(int argc, const char **argv) {
      */
 	string line;
 	stringstream result;
+  string in_file = "_none_";
     if (argc == 2) {
         ifstream file_content;
-    	cout << "opening file " << argv[1] << endl;
-    	file_content.open(argv[1]);
+        in_file = argv[1];
+    	cout << "opening file " << in_file << endl;
+    	file_content.open(in_file);
     	while(getline(file_content, line)) {
         	result << line << endl;
         }
@@ -145,8 +147,8 @@ int main(int argc, const char **argv) {
     cout << "Preprocessor task size: " << task_size << endl;
 
     cout << "Writing output..." << endl;
-    generate_cpp_input(solveable_in_poly_time, ordering, numeric_ordering, metric,
-                       mutexes, initial_state, goals, operators, axioms_rel,
+    generate_cpp_input(in_file, solveable_in_poly_time, ordering, numeric_ordering, 
+             metric, mutexes, initial_state, goals, operators, axioms_rel,
 					   axioms_numeric, axioms_func_comp, global_constraint,
 					   successor_generator, transition_graphs, causal_graph);
     cout << "done" << endl;

--- a/src/translate/options.py
+++ b/src/translate/options.py
@@ -11,6 +11,8 @@ def parse_args():
     argparser.add_argument(
         "task", help="path to task pddl file")
     argparser.add_argument(
+        "--sas_file", help="path to output sas file")
+    argparser.add_argument(
         "--relaxed", dest="generate_relaxed_task", action="store_true",
         help="output relaxed task (no delete effects)")
     argparser.add_argument(

--- a/src/translate/translate.py
+++ b/src/translate/translate.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 
 import sys
 
+
 def python_version_supported():
     major, minor = sys.version_info[:2]
     return (major == 2 and minor >= 7) or (major, minor) >= (3, 2)
@@ -18,10 +19,10 @@ from copy import deepcopy
 from itertools import product
 
 import axiom_rules
-import numeric_axiom_rules
 import fact_groups
 import instantiate
 import normalize
+import numeric_axiom_rules
 import options
 import pddl
 import pddl_parser
@@ -1023,7 +1024,7 @@ def main():
 #         print("Init = %s" % [sas_task.init.values[avar]])
 
     with timers.timing("Writing output"):
-        with open("output.sas", "w") as output_file:
+        with open(options.sas_file, "w") as output_file:
             sas_task.output(output_file)
     print("Done! %s" % timer)
 


### PR DESCRIPTION
Allow for `output.sas` and `output` files as command line arguments. May be useful when running multiple jobs in parallel without a container.